### PR TITLE
:sparkles: .execute함수를 이용하여 sql injection 방어 기능 추가 #37

### DIFF
--- a/models/initConnection.js
+++ b/models/initConnection.js
@@ -5,7 +5,9 @@ export default function initMySQLConnection(mysql) {
     user: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
-    connectionLimit: 5, // max connections
+    waitForConnections: true,
+    connectionLimit: 10, // max connections
+    queueLimit: 50,
   });
   return pool;
 }

--- a/models/insertNewUser.js
+++ b/models/insertNewUser.js
@@ -1,9 +1,10 @@
 import consoleLogger from '../controllers/consoleLogger.js';
 
 export default function insertNewUser(pool, user) {
-  const sql = 'INSERT INTO user SET ?';
+  const sql = 'INSERT INTO user (id, name, profileImage) VALUES (?, ?, ?)';
+
   pool
-    .query(sql, { id: user.id, name: user.username, profileImage: user.profileImage })
+    .execute(sql, [user.id, user.username, user.profileImage])
     .then((rows, fields) => consoleLogger.info('rows: ', rows))
     .catch(err => {
       if (err.code === 'ER_DUP_ENTRY') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2708,14 +2708,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mysql2/node_modules/sqlstring": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
-      "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/named-placeholders": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
@@ -3612,6 +3604,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
+      "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/statuses": {
       "version": "1.4.0",
@@ -6073,11 +6073,6 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
-        },
-        "sqlstring": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
-          "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
         }
       }
     },
@@ -6758,6 +6753,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
+    },
+    "sqlstring": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
+      "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
     },
     "statuses": {
       "version": "1.4.0",


### PR DESCRIPTION
:sparkles: .execute함수를 이용하여 sql injection 방어 기능 추가했습니다 #37

## 개요
.query 함수를 .execute 함수로 바꾸었고 그에 맞게 쿼리문을 수정하였습니다. 자세한건 이슈를 참고해주세요
## 작업 사항
pool.query 를 pool.execute로 바꾸었습니다. 
사용법은 쿼리문에서 데이터들만 ?으로 선언해주고, 순서에 맞게 배열로 선언해주면 됩니다. 노션을 참고해주세요

## 스크린샷 (optional)
