### PR TITLE
:sparkles: redis 활용한 월단위 캘린더 데이터 캐싱

### DIFF
--- a/controllers/monthController.js
+++ b/controllers/monthController.js
@@ -6,6 +6,7 @@ import {
 } from '../lib/calendar/monthUtils.js';
 import getHolidays from '../lib/calendar/holidaysUtils.js';
 import { selectMonthEvents } from '../models/accessEventTable.js';
+import consoleLogger from '../lib/consoleLogger.js';
 
 // month 데이터 json 으로 가공 & client 에 전송
 export default async function monthController(req, res) {
@@ -27,7 +28,6 @@ export default async function monthController(req, res) {
       monthIndex: month,
     });
   } catch (err) {
-    // TODO: 적절한 error message & res.status 설정
-    return null;
+    return res.status(500).end();
   }
 }

--- a/lib/calendar/cacheMonthData.js
+++ b/lib/calendar/cacheMonthData.js
@@ -1,0 +1,70 @@
+import redisClient from '../../config/createRedisClient.js';
+import consoleLogger from '../consoleLogger.js';
+import getHolidays from './holidaysUtils.js';
+import { checkYearMonthRange, getMonthDates, getMonthRange } from './monthUtils.js';
+
+// cache expiration 설정
+function setMonthCacheExpiration(cacheKey, year, month) {
+  const now = new Date();
+  const thisYear = now.getFullYear();
+  const thisMonth = now.getMonth();
+  const threeMonthsAgo = new Date(thisYear, thisMonth - 3, 1, 9);
+  const threeMonthsLater = new Date(thisYear, thisMonth + 3, 1, 9);
+  const reqMonth = new Date(year, month, 1, 9);
+
+  if (reqMonth >= threeMonthsAgo && reqMonth < threeMonthsLater) {
+    const sixMonthsLater = new Date(year, month + 6, 1, 9);
+    const expiration =
+      sixMonthsLater.getFullYear() > thisYear
+        ? new Date(thisYear + 1, 0, 1, 9) - now
+        : sixMonthsLater - now;
+    redisClient.expire(cacheKey, Math.floor(expiration / 1000));
+  } else {
+    redisClient.expire(cacheKey, 1800);
+  }
+}
+
+// cache 있으면 데이터 get & parsing 하고 return , 없으면 caching
+export default async function cacheMonthData(cacheKey, yearParam, monthParam) {
+  try {
+    // cache 존재
+    if (await redisClient.exists(cacheKey)) {
+      const monthData = await redisClient.hGetAll(cacheKey);
+
+      // string value 를 array 로 파싱
+      monthData.dates = JSON.parse(monthData.dates).map(day => new Date(day));
+      monthData.holidays = JSON.parse(monthData.holidays);
+      consoleLogger.info(`cacheMonthData : cached ${cacheKey} has been obtained`);
+      return monthData;
+    }
+
+    // cache 없을 때 다시 data 가공 후 hSet & expiration 설정
+    const { year, month } = checkYearMonthRange(yearParam, monthParam);
+    const { noWeeks, dates } = getMonthDates(year, month);
+    const holidays = await getHolidays(dates, year, month);
+    const { firstSQLDate, lastSQLDate } = getMonthRange(dates[0], dates.at(-1));
+
+    await redisClient.hSet(cacheKey, 'year', year);
+    await redisClient.hSet(cacheKey, 'month', month);
+    await redisClient.hSet(cacheKey, 'noWeeks', noWeeks);
+    await redisClient.hSet(cacheKey, 'dates', JSON.stringify(dates));
+    await redisClient.hSet(cacheKey, 'firstSQLDate', firstSQLDate);
+    await redisClient.hSet(cacheKey, 'lastSQLDate', lastSQLDate);
+    await redisClient.hSet(cacheKey, 'holidays', JSON.stringify(holidays));
+    setMonthCacheExpiration(cacheKey, year, month);
+    consoleLogger.info(`cacheMonthData : ${cacheKey} is successfully cached`);
+
+    return {
+      dates,
+      firstSQLDate,
+      holidays,
+      lastSQLDate,
+      month,
+      noWeeks,
+      year,
+    };
+  } catch (err) {
+    consoleLogger.error('cacheMonthData : cache error : ', err);
+    return err;
+  }
+}

--- a/lib/calendar/holidaysUtils.js
+++ b/lib/calendar/holidaysUtils.js
@@ -56,7 +56,7 @@ export default async function getHolidays(dates, year, month) {
       .filter(date => date >= dates[0] && date <= dates.at(-1))
       .map(date => date.toISOString());
   } catch (err) {
-    consoleLogger.err(`getHolidays: failed to fetch holiday data : ${err}`);
+    consoleLogger.error(`getHolidays: failed to fetch holiday data : ${err}`);
     return err;
   }
 }

--- a/lib/calendar/holidaysUtils.js
+++ b/lib/calendar/holidaysUtils.js
@@ -52,6 +52,7 @@ export default async function getHolidays(dates, year, month) {
         return data;
       })
     );
+    consoleLogger.info(`getHolidays: successfully fetched holidays data`);
     return holidaysXmlToDate(holidays)
       .filter(date => date >= dates[0] && date <= dates.at(-1))
       .map(date => date.toISOString());

--- a/lib/calendar/monthUtils.js
+++ b/lib/calendar/monthUtils.js
@@ -17,8 +17,11 @@ export function checkYearMonthRange(yearParam, monthParam) {
 // 해당 월의 주 수 & datetime array 반환
 export function getMonthDates(year, month) {
   const calendar = new Calendar(0);
-  const cur = calendar.monthDates(year, month);
-  return { noWeeks: cur.length, dates: cur.flat(1).map(date => new Date(date.setHours(9))) };
+  const monthDates = calendar.monthDates(year, month);
+  return {
+    noWeeks: monthDates.length,
+    dates: monthDates.flat(1).map(date => new Date(date.setHours(9))),
+  };
 }
 
 // 해당 달력에 표시될 처음 & 마지막 날짜 sql datetime string 으로 반환

--- a/lib/calendar/monthUtils.js
+++ b/lib/calendar/monthUtils.js
@@ -34,15 +34,17 @@ export function getMonthRange(first, last) {
 // day & events 맵핑, holiday flag & dateEvents 객체 반환
 export function mapDayEvent(dates, monthEvents, holidays) {
   return dates.map((day, index) => {
+    const dayString = day.toISOString();
+
     let isHoliday = 0; // 평일
-    if (holidays.includes(day.toISOString()) || !(index % 7)) {
+    if (holidays.includes(dayString) || !(index % 7)) {
       isHoliday = 2; // 일요일 + 공휴일
     } else if (index % 7 === 6) {
       isHoliday = 1; // 토요일
     }
 
     const eventArray = monthEvents
-      .filter(event => day.toISOString().slice(0, 11) === event.beginAt.toISOString().slice(0, 11))
+      .filter(event => dayString.slice(0, 11) === event.beginAt.toISOString().slice(0, 11))
       .map(event => {
         const eventUpdated = event;
         eventUpdated.duration = event.endAt.getDate() - event.beginAt.getDate() + 1;


### PR DESCRIPTION
## 개요
- 월단위 캘린더 데이터 요청 시 변하는 데이터, 변하지 않는 데이터로 구분
- 변하지 않는 데이터는 redis 활용해 캐싱
- flowchart
![Untitled Diagram drawio](https://user-images.githubusercontent.com/83805691/149620311-df13a727-e8f6-43dc-a9af-bcfb32c042ee.png)
- cache hash 구조
![Screen Shot 2022-01-15 at 8 38 32 PM](https://user-images.githubusercontent.com/83805691/149620455-008e215d-c2f6-4a98-abf2-edcbbdff84ad.png)

## 작업 사항
- 월단위 캘린더 데이터 caching (날짜 배치 & 공휴일 데이터)
- 위 flowchart 와 같이 caching & expiration 설정
  - 처음에는 더 길게 expiration time 을 설정해서 +- 1년 안의 데이터 cache 하려고 했는데 공휴일이 바뀔 수도 있겠다는 생각이 들어서 +- 3개월 간격으로 줄였습니다.
  - +3개월 범위인데 다음 해로 넘어간다면 현재 해까지 살아있는 걸로 한 것도 공휴일이 바뀔 수 있기 때문에 그렇게 했습니다...
## 변경점
- `monthController` 에서 err 발생 시 `res.status(500).end`
- cache 데이터를 받은 후 이벤트 & dates 맵핑을 해야하기 때문에 `hGetAll` 이후에 `JSON.parse()` 해주고 `monthUtils.js` 조금씩 수정했습니다.
- cur -> monthDates in `getMonthDates()`