### PR TITLE
♻️ refresh 토큰을 redis에 저장하여 성능 개선 #69

### DIFF
--- a/controllers/initializePassport.js
+++ b/controllers/initializePassport.js
@@ -28,7 +28,7 @@ export default function initializePassport(passport) {
           await insertUser(user);
           cb(null, user);
         } catch (err) {
-          consoleLogger.error('FortyTwoStrategy : error :', err);
+          consoleLogger.error('FortyTwoStrategy : error :', err.stack);
           cb(err);
         }
       }

--- a/controllers/logoutController.js
+++ b/controllers/logoutController.js
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import consoleLogger from '../lib/consoleLogger.js';
-import { deleteToken } from '../models/accessTokenTable.js';
+import { deleteToken } from '../models/accessTokenRedis.js';
 
 export default async function logoutController(req, res) {
   try {

--- a/lib/jwtUtils.js
+++ b/lib/jwtUtils.js
@@ -45,7 +45,8 @@ export async function verifyRefresh(token) {
     // DB에서 저장된 토큰을 Select
     const storedToken = await selectToken(id);
 
-    if (token.localeCompare(storedToken.content)) throw new Error('Token does not match!');
+    if (!storedToken) throw new Error('Token does not exist in DB');
+    if (token.localeCompare(storedToken)) throw new Error('Token does not match!');
 
     return {
       verified: true,
@@ -53,7 +54,7 @@ export async function verifyRefresh(token) {
       id,
     };
   } catch (err) {
-    consoleLogger.error('verifyRefresh : verify error : ', err);
+    consoleLogger.error('verifyRefresh : verify error : ', err.stack);
     return {
       verified: false,
       message: err.message,

--- a/lib/jwtUtils.js
+++ b/lib/jwtUtils.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
 import consoleLogger from './consoleLogger.js';
-import { insertToken, selectToken } from '../models/accessTokenTable.js';
+import { insertToken, selectToken } from '../models/accessTokenRedis.js';
 
 dotenv.config();
 

--- a/models/accessTokenRedis.js
+++ b/models/accessTokenRedis.js
@@ -3,7 +3,7 @@ import consoleLogger from '../lib/consoleLogger.js';
 
 export async function insertToken(id, token) {
   try {
-    const ret = await redisClient.setEx(id, 1.2096e6, token); // 2주 뒤 만료
+    const ret = await redisClient.setEx(`r_${id}`, 1.2096e6, token); // 2주 뒤 만료
     if (ret.localeCompare('OK')) throw new Error(`Fail to insert Token for ${id}`);
     consoleLogger.info(`insertToken : query success : refreshToken has issued for ${id}`);
   } catch (err) {
@@ -13,7 +13,7 @@ export async function insertToken(id, token) {
 
 export async function deleteToken(id) {
   try {
-    const ret = await redisClient.del(id);
+    const ret = await redisClient.del(`r_${id}`);
     if (ret !== 1) throw new Error(`Fail to delete Token for ${id}`);
     consoleLogger.info(`deleteToken : query success : refreshToken has deleted for ${id}`);
   } catch (err) {
@@ -23,7 +23,7 @@ export async function deleteToken(id) {
 
 export async function selectToken(id) {
   try {
-    const ret = await redisClient.get(id);
+    const ret = await redisClient.get(`r_${id}`);
     if (ret === null) throw new Error(`Fail to select Token for ${id}`);
     consoleLogger.info(`selectToken : query success : refreshToken for ${id} is ${ret}`);
     return ret;

--- a/models/accessTokenRedis.js
+++ b/models/accessTokenRedis.js
@@ -5,19 +5,19 @@ export async function insertToken(id, token) {
   try {
     const ret = await redisClient.setEx(`r_${id}`, 1.2096e6, token); // 2주 뒤 만료
     if (ret.localeCompare('OK')) throw new Error(`Fail to insert Token for ${id}`);
-    consoleLogger.info(`insertToken : query success : refreshToken has issued for ${id}`);
+    consoleLogger.info(`insertToken : cache success : refreshToken has been issued for ${id}`);
   } catch (err) {
-    consoleLogger.error('insertToken : query error : ', err.stack);
+    consoleLogger.error('insertToken : cache error : ', err.stack);
   }
 }
 
 export async function deleteToken(id) {
   try {
     const ret = await redisClient.del(`r_${id}`);
-    if (ret !== 1) throw new Error(`Fail to delete Token for ${id}`);
-    consoleLogger.info(`deleteToken : query success : refreshToken has deleted for ${id}`);
+    if (ret !== 1) throw new Error(`Failed to delete Token for ${id}`);
+    consoleLogger.info(`deleteToken : cache success : refreshToken has been deleted for ${id}`);
   } catch (err) {
-    consoleLogger.error('deleteToken : query error : ', err.stack);
+    consoleLogger.error('deleteToken : cache error : ', err.stack);
   }
 }
 
@@ -25,10 +25,10 @@ export async function selectToken(id) {
   try {
     const ret = await redisClient.get(`r_${id}`);
     if (ret === null) throw new Error(`Fail to select Token for ${id}`);
-    consoleLogger.info(`selectToken : query success : refreshToken for ${id} is ${ret}`);
+    consoleLogger.info(`selectToken : cache success : refreshToken for ${id} is ${ret}`);
     return ret;
   } catch (err) {
-    consoleLogger.error('selectToken : query error : ', err.stack);
+    consoleLogger.error('selectToken : cache error : ', err.stack);
     return null;
   }
 }

--- a/models/accessTokenRedis.js
+++ b/models/accessTokenRedis.js
@@ -4,7 +4,7 @@ import consoleLogger from '../lib/consoleLogger.js';
 export async function insertToken(id, token) {
   try {
     const ret = await redisClient.setEx(`r_${id}`, 1.2096e6, token); // 2주 뒤 만료
-    if (ret.localeCompare('OK')) throw new Error(`Fail to insert Token for ${id}`);
+    if (ret.localeCompare('OK')) throw new Error(`Failed to insert Token for ${id}`);
     consoleLogger.info(`insertToken : cache success : refreshToken has been issued for ${id}`);
   } catch (err) {
     consoleLogger.error('insertToken : cache error : ', err.stack);
@@ -24,7 +24,7 @@ export async function deleteToken(id) {
 export async function selectToken(id) {
   try {
     const ret = await redisClient.get(`r_${id}`);
-    if (ret === null) throw new Error(`Fail to select Token for ${id}`);
+    if (ret === null) throw new Error(`Failed to select Token for ${id}`);
     consoleLogger.info(`selectToken : cache success : refreshToken for ${id} is ${ret}`);
     return ret;
   } catch (err) {


### PR DESCRIPTION
## 개요
refreshtoken을 redis에 저장하여 로그인 시 및 refresh 토큰 비교시 속도를 향상시켰습니다.
consoleLogger에서 throw new Error() 로 만들어진 err를 출력할 때 빈 객체가 출력되던 문제를 해결했습니다.

## 작업 사항

- refresh 토큰을 redis에 저장하는 방식으로 바꿨습니다.
- redis 명령문에 맞게 에러 핸들링을 해주었습니다.
- new Error('str') 으로 throw된 에러의 메시지가 부적절하게 나오던 문제를
  수정하였습니다.
- verifyRefresh 에서 토큰이 DB에 없을때와 값이 다른 경우를
  분리하였습니다.

## 스크린샷 (optional)
