### PR TITLE
:sparkles: 인트라 이벤트 업데이트

### DIFF
--- a/db/getIntraEvents/getFtAccessToken.js
+++ b/db/getIntraEvents/getFtAccessToken.js
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import dotenv from 'dotenv';
+import consoleLogger from '../../lib/consoleLogger.js';
+
+dotenv.config({ path: 'project경로/.env' });
+
+export default async function getFtAccessToken(redisClient) {
+  try {
+    const exToken = await redisClient.get('ft_access_token');
+    if (!exToken) {
+      const res = await axios.post('https://api.intra.42.fr/oauth/token', {
+        grant_type: 'client_credentials',
+        client_id: process.env.FORTYTWO_APP_ID,
+        client_secret: process.env.FORTYTWO_APP_SECRET,
+      });
+      const newToken = res.data.access_token;
+      const result = await redisClient.setEx('ft_access_token', 7100, newToken);
+      if (result.localeCompare('OK')) throw new Error(`failed to insert ft access token`);
+      consoleLogger.info('getFtAccessToken : issued new token');
+      return newToken;
+    }
+    return exToken;
+  } catch (err) {
+    throw new Error(err.message);
+  }
+}

--- a/db/getIntraEvents/getUpdatedEvents.js
+++ b/db/getIntraEvents/getUpdatedEvents.js
@@ -1,0 +1,113 @@
+import axios from 'axios';
+import mysql from 'mysql2/promise';
+import getFtAccessToken from './getFtAccessToken.js';
+import redisClient from '../../config/createRedisClient.js';
+import consoleLogger from '../../lib/consoleLogger.js';
+import parseEventData from '../../lib/parseEventData.js';
+
+// 가장 최근의 intra event를 기준으로 그 이후 ~ 현재 시각 까지 업데이트된 event get
+async function getUpdatedIntraEvent(latestDate) {
+  try {
+    const token = await getFtAccessToken(redisClient);
+    if (!token) throw new Error('token is not exist');
+    latestDate.setMilliseconds(999);
+    const latestDateStr = JSON.stringify(latestDate);
+    const curDateStr = JSON.stringify(new Date());
+    const res = await axios.get(
+      `https://api.intra.42.fr/v2/campus/29/events?range[updated_at]=${latestDateStr},${curDateStr}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return res.data;
+  } catch (err) {
+    throw new Error(err.message);
+  }
+}
+
+// 가장 최근의 intra event를 기준으로 그 이후 ~ 현재 시각 까지 업데이트된 exam get
+async function getUpdatedIntraExam(latestDate) {
+  try {
+    const token = await getFtAccessToken(redisClient);
+    if (!token) throw new Error('token is not exist');
+    latestDate.setMilliseconds(999);
+    const latestDateStr = JSON.stringify(latestDate);
+    const curDateStr = JSON.stringify(new Date());
+    const res = await axios.get(
+      `https://api.intra.42.fr/v2/campus/29/exams?range[updated_at]=${latestDateStr},${curDateStr}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return res.data;
+  } catch (err) {
+    throw new Error(err.message);
+  }
+}
+
+async function selectLatestEvent(connection) {
+  const sql =
+    'SELECT modifiedAt FROM event WHERE modifiedAt=(SELECT Max(modifiedAt) FROM event ' +
+    'WHERE intraId IS NOT NULL AND category NOT IN ("exam"));';
+  const [rows] = await connection.query(sql);
+  consoleLogger.info('selectLatestEvent : query success : ', rows);
+  return rows[0];
+}
+
+async function selectLatestExam(connection) {
+  const sql =
+    'select modifiedAt FROM event WHERE modifiedAt=(SELECT Max(modifiedAt) FROM event ' +
+    'WHERE intraId IS NOT NULL AND category="exam");';
+  const [rows] = await connection.query(sql);
+  consoleLogger.info('selectLatestExam : query success : ', rows);
+  return rows[0];
+}
+
+async function insertUpdatedEventList(connection, eventList) {
+  if (eventList == null) return;
+  if (eventList.length === 0) return;
+  const sql =
+    'INSERT INTO event ' +
+    '(creator, title, personInCharge, beginAt, endAt, location, category, ' +
+    'topic, details, createdAt, modifiedAt, intraId) VALUES ? ' +
+    'ON DUPLICATE KEY UPDATE title = VALUES(title), personInCharge = VALUES(personIncharge), ' +
+    'beginAt = VALUES(beginAt), endAt = VALUES(endAt), location = VALUES(location), category = VALUES(category), ' +
+    'topic = VALUES(topic), details = VALUES(details), modifiedAt = VALUES(modifiedAt);';
+  const [rows] = await connection.query(sql, [eventList]);
+  consoleLogger.info('insertUpdatedEventList : query success : ', rows);
+}
+
+// event와 exam을 불러와서 db에 저장
+async function updateEventData() {
+  const connection = await mysql.createConnection({
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  });
+  try {
+    const { modifiedAt: latestEventDate } = await selectLatestEvent(connection);
+    const { modifiedAt: latestExamDate } = await selectLatestExam(connection);
+    const eventList = await getUpdatedIntraEvent(latestEventDate);
+    const examList = await getUpdatedIntraExam(latestExamDate);
+    eventList.push(...examList);
+    if (examList.length === 0) {
+      consoleLogger.info('updateEventData : no event to update', new Date());
+      return;
+    }
+    const parsedEvents = await parseEventData(eventList);
+    await insertUpdatedEventList(connection, parsedEvents);
+    consoleLogger.info('updateEventData : events updated!', new Date());
+  } catch (err) {
+    consoleLogger.error('updateEventData : ', new Date(), err.stack);
+  } finally {
+    redisClient.quit();
+    connection.end();
+  }
+}
+updateEventData();

--- a/db/getIntraEvents/getUpdatedEvents.js
+++ b/db/getIntraEvents/getUpdatedEvents.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import mysql from 'mysql2/promise';
-import getFtAccessToken from './getFtAccessToken.js';
 import redisClient from '../../config/createRedisClient.js';
+import getFtAccessToken from './getFtAccessToken.js';
 import consoleLogger from '../../lib/consoleLogger.js';
 import parseEventData from '../../lib/parseEventData.js';
 
@@ -9,7 +9,7 @@ import parseEventData from '../../lib/parseEventData.js';
 async function getUpdatedIntraEvent(latestDate) {
   try {
     const token = await getFtAccessToken(redisClient);
-    if (!token) throw new Error('token is not exist');
+    if (!token) throw new Error('token does not exist');
     latestDate.setMilliseconds(999);
     const latestDateStr = JSON.stringify(latestDate);
     const curDateStr = JSON.stringify(new Date());
@@ -31,7 +31,7 @@ async function getUpdatedIntraEvent(latestDate) {
 async function getUpdatedIntraExam(latestDate) {
   try {
     const token = await getFtAccessToken(redisClient);
-    if (!token) throw new Error('token is not exist');
+    if (!token) throw new Error('token does not exist');
     latestDate.setMilliseconds(999);
     const latestDateStr = JSON.stringify(latestDate);
     const curDateStr = JSON.stringify(new Date());
@@ -60,7 +60,7 @@ async function selectLatestEvent(connection) {
 
 async function selectLatestExam(connection) {
   const sql =
-    'select modifiedAt FROM event WHERE modifiedAt=(SELECT Max(modifiedAt) FROM event ' +
+    'SELECT modifiedAt FROM event WHERE modifiedAt=(SELECT Max(modifiedAt) FROM event ' +
     'WHERE intraId IS NOT NULL AND category="exam");';
   const [rows] = await connection.query(sql);
   consoleLogger.info('selectLatestExam : query success : ', rows);
@@ -68,8 +68,6 @@ async function selectLatestExam(connection) {
 }
 
 async function insertUpdatedEventList(connection, eventList) {
-  if (eventList == null) return;
-  if (eventList.length === 0) return;
   const sql =
     'INSERT INTO event ' +
     '(creator, title, personInCharge, beginAt, endAt, location, category, ' +
@@ -96,7 +94,7 @@ async function updateEventData() {
     const eventList = await getUpdatedIntraEvent(latestEventDate);
     const examList = await getUpdatedIntraExam(latestExamDate);
     eventList.push(...examList);
-    if (examList.length === 0) {
+    if (!eventList.length) {
       consoleLogger.info('updateEventData : no event to update', new Date());
       return;
     }
@@ -110,4 +108,5 @@ async function updateEventData() {
     connection.end();
   }
 }
+
 updateEventData();

--- a/lib/parseEventData.js
+++ b/lib/parseEventData.js
@@ -1,5 +1,3 @@
-import consoleLogger from './consoleLogger.js';
-
 // event의 topic으로 category 분류
 function setCategory(topic, name) {
   let category;
@@ -21,30 +19,23 @@ function setCategory(topic, name) {
 }
 
 // db 삽입을 위해 data 가공
-// creator, title, beginAt, endAt, location, category, topic, description
-// , createAt, updatedAt, intraId
 export default async function parseEventData(eventList) {
-  try {
-    const parsedEvents = [];
-    await eventList.forEach(event => {
-      parsedEvents.push([
-        424242,
-        event.name,
-        null,
-        new Date(event.begin_at),
-        new Date(event.end_at),
-        event.location,
-        setCategory(event.kind, event.name),
-        event.name,
-        event.description ? event.description : null, // exam에서 undefined
-        new Date(event.created_at),
-        new Date(event.updated_at),
-        event.id,
-      ]);
-    });
-    return parsedEvents;
-  } catch (err) {
-    consoleLogger.error('parseEventData : ', err.stack);
-    return null;
-  }
+  const parsedEvents = [];
+  await eventList.forEach(event => {
+    parsedEvents.push([
+      424242,
+      event.name,
+      null,
+      new Date(event.begin_at),
+      new Date(event.end_at),
+      event.location,
+      setCategory(event.kind, event.name),
+      event.name,
+      event.description ? event.description : null, // exam에서 undefined
+      new Date(event.created_at),
+      new Date(event.updated_at),
+      event.id,
+    ]);
+  });
+  return parsedEvents;
 }


### PR DESCRIPTION
## 개요
- 10분마다 db의 가장 최신 데이터를 가져와 그 이후의 이벤트를 업데이트
## 작업 사항
- db의 가장 최신 데이터를 가져와 그 이후의 이벤트를 업데이트
- init과 update 모두 가능하게 getFtAccessToken.js 모듈화
- cron으로 실행 가능하도록 env 경로 재설정
## 변경 사항
- env 경로설정을 해준다면 기존 `getEvents.js`도 아무 경로에서 실행할 수 있습니다.
- 에러 처리부분을 상황에 맞게 변경하였습니다.
## 주의 사항
- 실행 전 `getFtAccessToken.js`의 env 경로 설정 부분을 환경에 맞게 세팅 해주세요.
## 실행 방법
- `crontab -e`로 crontab 설정파일 실행
- crontab 설정파일에 해당 스크립트 입력
`*/10 * * * * [node 경로] [프로젝트경로]/db/getIntraEvents/getUpdatedEvents.js >> [로그파일] 2>&1`

close #98