### PR TITLE
:bug: fix : 서버 공휴일 데이터 fetch 오류 #144

### DIFF
--- a/db/cacheHolidays/cacheNextMonth.js
+++ b/db/cacheHolidays/cacheNextMonth.js
@@ -8,8 +8,8 @@ import consoleLogger from '../../lib/consoleLogger.js';
 async function cacheNextMonth() {
   try {
     const today = localizeDateTime(new Date());
-    const [year, month] = [today.getFullYear() + 1, today.getMonth() + 1];
-    const { dates } = getMonthDates(year, month);
+    const [year, month] = [today.getFullYear() + 1, today.getMonth()];
+    const { dates } = getMonthDates(year, month + 1);
 
     const holidays = await getHolidays(dates, year, month);
     const expire = Math.ceil((new Date(year, month + 12, 1, 9) - today) / 1000);

--- a/db/cacheHolidays/holidaysUtils.js
+++ b/db/cacheHolidays/holidaysUtils.js
@@ -55,6 +55,9 @@ export default async function getHolidays(dates, year, month) {
         return data;
       })
     );
+
+    if (holidays.join().match('ERROR')) throw new Error('failed to fetch holiday data');
+
     return holidaysXmlToDate(holidays)
       .filter(date => date >= dates[0] && date <= dates.at(-1))
       .map(date => date.toISOString());


### PR DESCRIPTION
## 개요
- cacheNextMonth 로 매월 1일 다음해 해당 월 데이터를 fetch 해야하는데 그 다음 월을 caching 하고 있어서 수정했습니다.
- api get 실패인데 axios 에 잡히지 않는 에러는 throw 되지 않아서 로그에 success 로 표시되는 것 확인하고,  xml 포맷 데이터 리턴 값에 'ERROR' 문구가 있는지 여부로 한번 더 에러 핸들링해줬습니다.
## 스크린샷 (optional)
- axios 에 잡히지 않는 에러 시 xml 포맷 api get 리턴  예시 (서버에서 이 경우가 안 걸러졌어서 success 문구에 속았던 겁니다)
<img width="595" alt="Screen Shot 2022-02-02 at 12 05 36 AM" src="https://user-images.githubusercontent.com/83805691/151996527-9526fc15-93e0-4bed-a7f3-38a6821c3a3d.png">

close #144 
