### PR TITLE
:lipstick: sweetalert2 폰트 크기 수정

### DIFF
--- a/public/stylesheets/presets/layout.css
+++ b/public/stylesheets/presets/layout.css
@@ -69,3 +69,7 @@ body {
 .hidden {
   display: none;
 }
+
+.swal2-title {
+  font-size: 1.65em !important;
+}

--- a/public/stylesheets/presets/mobile_spec.css
+++ b/public/stylesheets/presets/mobile_spec.css
@@ -132,4 +132,8 @@ body {
   .details-content {
     width: 95%;
   }
+
+  .swal2-title {
+    font-size: 1.5em !important;
+  }
 }


### PR DESCRIPTION
## 개요
sweetalert의 폰트 사이즈를 줄였습니다. iphone se보다 작은 폰에서는 여전히 개행이 생깁니다.

## 스크린샷 (optional)
<img width="779" alt="Screen Shot 2022-02-11 at 10 15 51 AM" src="https://user-images.githubusercontent.com/79127797/153523382-ab423eea-056b-4e5f-83ed-7e48f50380dd.png">

