### PR TITLE
:bug: fix : 알림 설정 꺼져있을 때 이벤트 상세정보 팝업 알림 설정 UI 활성화 현상

### DIFF
--- a/src/javascripts/notification/initNotificationSetting.js
+++ b/src/javascripts/notification/initNotificationSetting.js
@@ -5,7 +5,9 @@ import { alertModal } from '../utils/sweetAlertMixin.js';
 async function initNotificationCheckbox(checkboxList) {
   const registration = await navigator.serviceWorker.getRegistration();
 
-  if (registration) {
+  if (!registration)
+    document.querySelector('#details-notification').disabled = true;
+  else {
     const notificationSelect = document.querySelector('#details-notification');
 
     await registration.ready;


### PR DESCRIPTION
## 개요
- 사용자가 처음 서비스에 접속 할 때 혹은 사용자가 브라우저에서 직접 serviceWorker registration 을 unregister 했을 때, 알림 설정 스위치는 꺼져있지만 이벤트 상세정보 팝업 알림 설정 `<select>` 태그는 활성화 돼있는 오류 있어서 수정했습니다.
close #204
