### PR TITLE
:recycle: refresh token 여러 브라우저에서 공유하도록 개선

### DIFF
--- a/lib/jwtUtils.js
+++ b/lib/jwtUtils.js
@@ -57,8 +57,14 @@ export async function verifyRefresh(token) {
 // refresh가 없을 때 refresh & access 토큰을 생성하고 쿠키에 저장
 export async function setTokens(res, user) {
   const accessToken = accessSign(user.id);
-  const refreshToken = refreshSign(user.id);
+  let refreshToken = await selectToken(user.id);
 
+  console.log('refresh token is ', refreshToken);
+  if (!refreshToken) {
+    refreshToken = refreshSign(user.id);
+    await insertToken(user.id, refreshToken);
+    console.log('julebabo');
+  }
   res.cookie('accessToken', accessToken, {
     secure: true,
     httpOnly: true,
@@ -72,5 +78,4 @@ export async function setTokens(res, user) {
     expires: new Date(Date.now() + 1.2096e9), // 2주 뒤 만료
     sameSite: 'lax',
   });
-  await insertToken(user.id, refreshToken);
 }

--- a/lib/jwtUtils.js
+++ b/lib/jwtUtils.js
@@ -59,11 +59,9 @@ export async function setTokens(res, user) {
   const accessToken = accessSign(user.id);
   let refreshToken = await selectToken(user.id);
 
-  console.log('refresh token is ', refreshToken);
   if (!refreshToken) {
     refreshToken = refreshSign(user.id);
     await insertToken(user.id, refreshToken);
-    console.log('julebabo');
   }
   res.cookie('accessToken', accessToken, {
     secure: true,


### PR DESCRIPTION
## 개요
- 기존 여러브라우저에서 refresh token이 무용지물이던 문제 개선
## 작업 사항
- refresh token이 서버에 저장되어 있으면 로그인 시 저장된 토큰을 쿠키에 저장해줍니다.
- close  #203