### PR TITLE
:sparkles: 이벤트 상세정보 닫기 추가설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3899,9 +3899,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/moment": {
       "version": "2.29.1",
@@ -8907,9 +8907,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "moment": {
       "version": "2.29.1",

--- a/src/javascripts/eventDetail/clickExitOrShareButton.js
+++ b/src/javascripts/eventDetail/clickExitOrShareButton.js
@@ -4,6 +4,19 @@ import generatePromotion from '../eventPromotion/generatePromotion.js';
 export default function clickExitOrShareButton(eventParam, eventId) {
   const exitButton = document.querySelector('.details-exit-button');
   const shareButton = document.querySelector('.details-share-button');
+  const detailsLayout = document.querySelector('.layout-details');
+  const detailsPopup = document.querySelector('.details-content');
+
+  // 이벤트 상세보기 팝업 밖에서 클릭시, 팝업 닫힘
+  detailsLayout.addEventListener('click', event => {
+    if (!detailsPopup.contains(event.target)) detailsLayout.style.display = 'none';
+  });
+
+  // ESC 누를 시, 이벤트 상세보기 팝업 닫힘
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') detailsLayout.style.display = 'none';
+  });
+
   exitButton.addEventListener('click', () => {
     document.querySelector('.layout-details').style.display = 'none';
   });

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -21,7 +21,7 @@
       <a href="/login/42">
         <button class="login-button xlarge text-bold" type="button">LOG IN</button>
       </a>
-      <p class="login-version small text-italic">BETA</p>
+      <p class="login-version small text-italic">v1.0.0</p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## 개요
이벤트 상세정보 팝업 닫는 방법 추가 설정
## 작업 사항
addEventListener를 이용해, ESC 키보드 버튼 누르거나 팝업 바깥에서 마우스 클릭시, 이벤트 상세페이지 팝업이 없어지게 설정하였습니다.
