### PR TITLE
🐛 fix : profile image 주소 위치 변경

### DIFF
--- a/controllers/initializePassport.js
+++ b/controllers/initializePassport.js
@@ -7,7 +7,7 @@ function profileToUser(profile) {
   const user = {
     id: profile.id,
     username: profile.username,
-    profileImage: profile.photos[0].value,
+    profileImage: profile._json.image.link,
   };
   logger.info(`profileToUser : ${JSON.stringify(user)}`);
   return user;


### PR DESCRIPTION
## 개요
- 42 passport 에서 제공하는 profile 객체에서 프로필 이미지 주소 위치가 기존에는 profile.photo[0] 이 었는데 profile._json.image.link 로 변경되어서 db 에 JS undefined 값을 넣는 문제 해결

close #210 